### PR TITLE
Plot save functionality

### DIFF
--- a/src/Synaptipy/application/gui/analysis_tabs/base.py
+++ b/src/Synaptipy/application/gui/analysis_tabs/base.py
@@ -237,6 +237,18 @@ class BaseAnalysisTab(QtWidgets.QWidget):
         self.reset_view_button.clicked.connect(self._on_reset_view_clicked)
         
         button_layout.addWidget(self.reset_view_button)
+        
+        # Create save plot button
+        self.save_plot_button = QtWidgets.QPushButton("Save Plot")
+        self.save_plot_button.setToolTip("Save plot as PNG or PDF")
+        
+        # Apply consistent button styling
+        style_button(self.save_plot_button)
+        
+        # Connect to save functionality
+        self.save_plot_button.clicked.connect(self._on_save_plot_clicked)
+        
+        button_layout.addWidget(self.save_plot_button)
         button_layout.addStretch()  # Push button to center
         
         # Add button layout to main layout
@@ -249,6 +261,42 @@ class BaseAnalysisTab(QtWidgets.QWidget):
         log.info(f"[ANALYSIS-BASE] Reset view clicked for {self.__class__.__name__}")
         self.auto_range_plot()
         log.debug(f"[ANALYSIS-BASE] Reset view triggered for {self.__class__.__name__}")
+
+    def _on_save_plot_clicked(self):
+        """Handle save plot button click."""
+        log.info(f"[ANALYSIS-BASE] Save plot clicked for {self.__class__.__name__}")
+        
+        if not self.plot_widget:
+            log.warning(f"[ANALYSIS-BASE] No plot widget available for saving")
+            return
+            
+        try:
+            from Synaptipy.application.gui.plot_save_dialog import save_plot_with_dialog
+            
+            # Generate default filename based on tab name
+            default_filename = f"{self.__class__.__name__.lower().replace('tab', '')}_plot"
+            
+            # Show save dialog and save plot
+            success = save_plot_with_dialog(
+                self.plot_widget, 
+                parent=self, 
+                default_filename=default_filename
+            )
+            
+            if success:
+                log.info(f"[ANALYSIS-BASE] Plot saved successfully for {self.__class__.__name__}")
+            else:
+                log.debug(f"[ANALYSIS-BASE] Plot save cancelled for {self.__class__.__name__}")
+                
+        except Exception as e:
+            log.error(f"[ANALYSIS-BASE] Failed to save plot for {self.__class__.__name__}: {e}")
+            # Show error message to user
+            from PySide6.QtWidgets import QMessageBox
+            QMessageBox.critical(
+                self, 
+                "Save Error", 
+                f"Failed to save plot:\n{str(e)}"
+            )
 
     def _setup_zoom_sync(self):
         """Initialize the zoom synchronization manager for reset functionality only."""

--- a/src/Synaptipy/application/gui/plot_save_dialog.py
+++ b/src/Synaptipy/application/gui/plot_save_dialog.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Plot Save Dialog for Synaptipy
+
+This module provides a dialog for saving plots as PNG or PDF files.
+Users can select the file path, name, and format.
+
+This file is part of Synaptipy, licensed under the GNU Affero General Public License v3.0.
+See the LICENSE file in the root of the repository for full license details.
+"""
+
+from PySide6 import QtWidgets, QtCore, QtGui
+import pyqtgraph as pg
+import logging
+import os
+from typing import Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+
+class PlotSaveDialog(QtWidgets.QDialog):
+    """Dialog for saving plots as PNG or PDF files."""
+    
+    def __init__(self, parent=None, default_filename: str = "plot"):
+        super().__init__(parent)
+        self.setWindowTitle("Save Plot")
+        self.setModal(True)
+        self.setMinimumWidth(500)
+        
+        self.default_filename = default_filename
+        self.selected_path = ""
+        self.selected_format = "png"
+        
+        self._setup_ui()
+        self._connect_signals()
+        
+    def _setup_ui(self):
+        """Setup the user interface."""
+        layout = QtWidgets.QVBoxLayout(self)
+        
+        # File path selection
+        path_group = QtWidgets.QGroupBox("File Path")
+        path_layout = QtWidgets.QHBoxLayout(path_group)
+        
+        self.path_edit = QtWidgets.QLineEdit()
+        self.path_edit.setPlaceholderText("Select file path...")
+        self.path_edit.setText(os.path.expanduser("~/Desktop"))
+        
+        self.browse_button = QtWidgets.QPushButton("Browse...")
+        self.browse_button.setToolTip("Browse for save location")
+        
+        path_layout.addWidget(self.path_edit)
+        path_layout.addWidget(self.browse_button)
+        
+        layout.addWidget(path_group)
+        
+        # File name and format
+        file_group = QtWidgets.QGroupBox("File Details")
+        file_layout = QtWidgets.QGridLayout(file_group)
+        
+        # File name
+        file_layout.addWidget(QtWidgets.QLabel("File Name:"), 0, 0)
+        self.filename_edit = QtWidgets.QLineEdit()
+        self.filename_edit.setText(self.default_filename)
+        file_layout.addWidget(self.filename_edit, 0, 1)
+        
+        # File format
+        file_layout.addWidget(QtWidgets.QLabel("Format:"), 1, 0)
+        self.format_combo = QtWidgets.QComboBox()
+        self.format_combo.addItems(["PNG", "PDF"])
+        self.format_combo.setCurrentText("PNG")
+        file_layout.addWidget(self.format_combo, 1, 1)
+        
+        # File extension (read-only)
+        file_layout.addWidget(QtWidgets.QLabel("Extension:"), 2, 0)
+        self.extension_label = QtWidgets.QLabel(".png")
+        self.extension_label.setStyleSheet("color: gray;")
+        file_layout.addWidget(self.extension_label, 2, 1)
+        
+        layout.addWidget(file_group)
+        
+        # Preview of full path
+        preview_group = QtWidgets.QGroupBox("Full Path Preview")
+        preview_layout = QtWidgets.QVBoxLayout(preview_group)
+        
+        self.preview_label = QtWidgets.QLabel()
+        self.preview_label.setStyleSheet("color: blue; font-family: monospace; padding: 5px; border: 1px solid #ccc; background-color: #f9f9f9;")
+        self.preview_label.setWordWrap(True)
+        self._update_preview()
+        
+        preview_layout.addWidget(self.preview_label)
+        layout.addWidget(preview_group)
+        
+        # Buttons
+        button_layout = QtWidgets.QHBoxLayout()
+        button_layout.addStretch()
+        
+        self.cancel_button = QtWidgets.QPushButton("Cancel")
+        self.save_button = QtWidgets.QPushButton("Save Plot")
+        self.save_button.setDefault(True)
+        
+        button_layout.addWidget(self.cancel_button)
+        button_layout.addWidget(self.save_button)
+        
+        layout.addLayout(button_layout)
+        
+    def _connect_signals(self):
+        """Connect UI signals."""
+        self.browse_button.clicked.connect(self._browse_path)
+        self.path_edit.textChanged.connect(self._update_preview)
+        self.filename_edit.textChanged.connect(self._update_preview)
+        self.format_combo.currentTextChanged.connect(self._update_preview)
+        
+        self.cancel_button.clicked.connect(self.reject)
+        self.save_button.clicked.connect(self._save_plot)
+        
+    def _browse_path(self):
+        """Browse for save directory."""
+        current_path = self.path_edit.text()
+        if not current_path or not os.path.exists(current_path):
+            current_path = os.path.expanduser("~/Desktop")
+            
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Select Save Directory", current_path
+        )
+        
+        if directory:
+            self.path_edit.setText(directory)
+            
+    def _update_preview(self):
+        """Update the full path preview."""
+        path = self.path_edit.text()
+        filename = self.filename_edit.text()
+        format_text = self.format_combo.currentText().lower()
+        
+        if path and filename:
+            full_path = os.path.join(path, f"{filename}.{format_text}")
+            self.preview_label.setText(full_path)
+        else:
+            self.preview_label.setText("")
+            
+    def _save_plot(self):
+        """Save the plot and close dialog."""
+        path = self.path_edit.text()
+        filename = self.filename_edit.text()
+        format_text = self.format_combo.currentText().lower()
+        
+        if not path or not filename:
+            QtWidgets.QMessageBox.warning(
+                self, "Invalid Input", 
+                "Please provide both a path and filename."
+            )
+            return
+            
+        if not os.path.exists(path):
+            QtWidgets.QMessageBox.warning(
+                self, "Invalid Path", 
+                f"The selected path does not exist:\n{path}"
+            )
+            return
+            
+        # Store the selected values
+        self.selected_path = path
+        self.selected_format = format_text
+        
+        # Close dialog with accept
+        self.accept()
+        
+    def get_save_info(self) -> Tuple[str, str]:
+        """Get the selected save path and format.
+        
+        Returns:
+            Tuple[str, str]: (full_file_path, format)
+        """
+        path = self.path_edit.text()
+        filename = self.filename_edit.text()
+        format_text = self.format_combo.currentText().lower()
+        
+        full_path = os.path.join(path, f"{filename}.{format_text}")
+        return full_path, format_text
+
+
+def save_plot_as_image(plot_widget: pg.PlotWidget, file_path: str, format_type: str = "png") -> bool:
+    """Save a plot widget as an image file.
+    
+    Args:
+        plot_widget: The PyQtGraph plot widget to save
+        file_path: Full path where to save the file
+        format_type: File format ("png" or "pdf")
+        
+    Returns:
+        bool: True if save was successful, False otherwise
+    """
+    try:
+        if format_type.lower() == "png":
+            # Save as PNG
+            plot_widget.grab().save(file_path, "PNG")
+            log.info(f"Plot saved as PNG: {file_path}")
+            return True
+            
+        elif format_type.lower() == "pdf":
+            # Save as PDF using QPrinter
+            from PySide6.QtPrintSupport import QPrinter
+            from PySide6.QtGui import QPainter
+            
+            printer = QPrinter(QPrinter.PrinterMode.HighResolution)
+            printer.setOutputFormat(QPrinter.OutputFormat.PdfFormat)
+            printer.setOutputFileName(file_path)
+            
+            # Get the plot item and render it
+            plot_item = plot_widget.getPlotItem()
+            if plot_item:
+                painter = QPainter()
+                if painter.begin(printer):
+                    # Render the plot to the printer
+                    plot_item.render(painter)
+                    painter.end()
+                    log.info(f"Plot saved as PDF: {file_path}")
+                    return True
+                else:
+                    log.error(f"Failed to begin painting for PDF: {file_path}")
+                    return False
+            else:
+                log.error(f"No plot item found for PDF export: {file_path}")
+                return False
+        else:
+            log.error(f"Unsupported format: {format_type}")
+            return False
+            
+    except Exception as e:
+        log.error(f"Failed to save plot as {format_type}: {e}")
+        return False
+
+
+def save_plot_with_dialog(plot_widget: pg.PlotWidget, parent=None, default_filename: str = "plot") -> bool:
+    """Show save plot dialog and save the plot if user confirms.
+    
+    Args:
+        plot_widget: The PyQtGraph plot widget to save
+        parent: Parent widget for the dialog
+        default_filename: Default filename (without extension)
+        
+    Returns:
+        bool: True if plot was saved successfully, False otherwise
+    """
+    try:
+        dialog = PlotSaveDialog(parent, default_filename)
+        if dialog.exec() == QtWidgets.QDialog.DialogCode.Accepted:
+            file_path, format_type = dialog.get_save_info()
+            return save_plot_as_image(plot_widget, file_path, format_type)
+        return False
+        
+    except Exception as e:
+        log.error(f"Failed to show save plot dialog: {e}")
+        return False


### PR DESCRIPTION
This pull request adds a user-friendly "Save Plot" feature to the analysis and explorer tabs, allowing users to export plots as PNG or PDF files via a dialog. It introduces a new `plot_save_dialog.py` module, integrates save buttons into relevant UI components, and provides robust error handling and state persistence for save locations.

**New Save Plot Functionality:**

- Added a reusable save plot dialog (`PlotSaveDialog`) supporting PNG and PDF export, with directory/filename selection, format choice, and a preview of the save path. The dialog remembers the last save location using `QSettings` for user convenience. (`src/Synaptipy/application/gui/plot_save_dialog.py`)

**Integration into Analysis and Explorer Tabs:**

- Analysis tabs: Added a "Save Plot" button to the base tab UI, styled consistently, and connected it to a handler that invokes the save dialog and manages error reporting. (`src/Synaptipy/application/gui/analysis_tabs/base.py`) [[1]](diffhunk://#diff-835a361f6a224690a35001dca90debc2a12dc94af3c2443951b6695f668f6cdcR240-R251) [[2]](diffhunk://#diff-835a361f6a224690a35001dca90debc2a12dc94af3c2443951b6695f668f6cdcR265-R300)
- Explorer tab: Added a "Save Plot" button to the view controls, connected it to a handler that saves the current plot or layout, with appropriate logging and user feedback. (`src/Synaptipy/application/gui/explorer_tab.py`) [[1]](diffhunk://#diff-f5604b603d370a2ed581766b67aee4aa2c1523a29f91b2396a62af1ac8a01740R434-R437) [[2]](diffhunk://#diff-f5604b603d370a2ed581766b67aee4aa2c1523a29f91b2396a62af1ac8a01740R540) [[3]](diffhunk://#diff-f5604b603d370a2ed581766b67aee4aa2c1523a29f91b2396a62af1ac8a01740R2919-R2962)

**Supporting Features and Error Handling:**

- The save logic ensures only available plots are saved, provides user feedback for errors or invalid input, and uses robust exception handling to prevent crashes. (`src/Synaptipy/application/gui/analysis_tabs/base.py`, `src/Synaptipy/application/gui/explorer_tab.py`, `src/Synaptipy/application/gui/plot_save_dialog.py`) [[1]](diffhunk://#diff-835a361f6a224690a35001dca90debc2a12dc94af3c2443951b6695f668f6cdcR265-R300) [[2]](diffhunk://#diff-f5604b603d370a2ed581766b67aee4aa2c1523a29f91b2396a62af1ac8a01740R2919-R2962) [[3]](diffhunk://#diff-c2c9d01272a75eabe737ad9cda3f3305622eeab21f634f8fbb7053493f0274c5R1-R340)