### PR TITLE
ci: fix coverage badge push and update actions for Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,7 @@ jobs:
       - name: Find installer workflow run for this commit
         id: installer_run
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -391,14 +391,14 @@ jobs:
           echo "notes_file=release_notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub Release
-        # softprops/action-gh-release@v2 creates the release if it does not exist
+        # softprops/action-gh-release@v3 creates the release if it does not exist
         # and updates (appends files to) the release if it was already created by
         # the installer.yml workflow running in parallel.  The old
         # "gh release delete + recreate" pattern was destructive: it wiped any
         # .exe / .dmg binaries that installer.yml had already attached, because
         # both workflows fire in parallel on the same tag push.
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: "${{ github.ref_name }} (${{ steps.pre.outputs.label }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
     # Push core test coverage badge endpoint.json to the data branch so the
     - name: Upload coverage to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
@@ -127,10 +127,13 @@ jobs:
       continue-on-error: true   # badge push is informational; must not block the build
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        QT_QPA_PLATFORM: offscreen
       run: |
-        xvfb-run python -m pytest -p faulthandler tests/core/ -q --cov=src/Synaptipy/core --cov-report=term --cov-report=xml --cov-fail-under=0
-        CORE_COVERAGE=$(python -m coverage report --format=total 2>/dev/null || echo "0")
+        # Read coverage collected during the main test run and filter to core/.
+        # Do NOT re-run pytest here: conftest.py calls os._exit() in
+        # pytest_sessionfinish, which kills the process before pytest-cov can
+        # write coverage.xml, causing set -e to abort the script before the
+        # badge JSON is pushed.
+        CORE_COVERAGE=$(python -m coverage report --include="*/Synaptipy/core/**" --format=total 2>/dev/null || echo "0")
         if   [ "$CORE_COVERAGE" -ge 90 ]; then COLOR="brightgreen"
         elif [ "$CORE_COVERAGE" -ge 75 ]; then COLOR="green"
         elif [ "$CORE_COVERAGE" -ge 60 ]; then COLOR="yellow"


### PR DESCRIPTION
## Fixes

### Coverage badge showing 0%
The `Push coverage badge data` step was re-running pytest, which triggered
`conftest.py::pytest_sessionfinish` → `os._exit()` before pytest-cov could
write `coverage.xml`. With `set -e` in bash, the non-zero exit code aborted
the script before `git push` ran. Fix: read coverage data already collected
by the main test run via `python -m coverage report --include='*/Synaptipy/core/**'`.
No second pytest invocation needed.

### Node.js 24 (mandatory from 2026-06-16)
- `codecov/codecov-action` v5 → v7
- `actions/github-script` v7 → v9
- `softprops/action-gh-release` v2 → v3

Closes #23, #24, #26